### PR TITLE
Fix BFS/DFS Graph Traversal visualization rendering issue

### DIFF
--- a/algorithms/bfs-dfs-graph-traversal.html
+++ b/algorithms/bfs-dfs-graph-traversal.html
@@ -489,7 +489,7 @@
                     if (!this.graph[i].includes(next)) {
                         this.graph[i].push(next);
                         this.graph[next].push(i);
-                        this.links.push({ source: i, target: next });
+                        this.links.push({ source: this.nodes[i], target: this.nodes[next] });
                     }
                 }
 
@@ -505,12 +505,13 @@
                     if (from !== to && !this.graph[from].includes(to)) {
                         this.graph[from].push(to);
                         this.graph[to].push(from);
-                        this.links.push({ source: from, target: to });
+                        this.links.push({ source: this.nodes[from], target: this.nodes[to] });
                         edgesAdded++;
                     }
                     attempts++;
                 }
 
+                console.log('Generated graph:', this.nodes.length, 'nodes,', this.links.length, 'links');
                 this.renderGraph();
                 this.resetStats();
             }
@@ -518,6 +519,8 @@
             renderGraph() {
                 // Clear previous content
                 this.g.selectAll('*').remove();
+
+                console.log('Rendering graph with', this.nodes.length, 'nodes and', this.links.length, 'links');
 
                 // Update simulation
                 this.simulation.nodes(this.nodes);
@@ -527,13 +530,18 @@
                 const link = this.g.selectAll('.link')
                     .data(this.links)
                     .join('line')
-                    .attr('class', 'link');
+                    .attr('class', 'link')
+                    .attr('x1', d => d.source.x)
+                    .attr('y1', d => d.source.y)
+                    .attr('x2', d => d.target.x)
+                    .attr('y2', d => d.target.y);
 
                 // Nodes
                 const node = this.g.selectAll('.node')
                     .data(this.nodes)
                     .join('g')
                     .attr('class', 'node')
+                    .attr('transform', d => `translate(${d.x},${d.y})`)
                     .call(this.drag(this.simulation));
 
                 node.append('circle')
@@ -542,6 +550,18 @@
                 node.append('text')
                     .text(d => d.label)
                     .attr('dy', '0.31em');
+
+                // Update positions on simulation tick
+                this.simulation.on('tick', () => {
+                    link
+                        .attr('x1', d => d.source.x)
+                        .attr('y1', d => d.source.y)
+                        .attr('x2', d => d.target.x)
+                        .attr('y2', d => d.target.y);
+
+                    node
+                        .attr('transform', d => `translate(${d.x},${d.y})`);
+                });
 
                 // Start simulation
                 this.simulation.alpha(1).restart();


### PR DESCRIPTION
## Bug Fix: BFS/DFS Graph Traversal Visualization

### Problem:
The BFS/DFS Graph Traversal visualization was showing an empty area with only a loading spinner, indicating that the D3.js force simulation was not properly rendering the graph nodes and links.

### Root Cause:
1. Missing Initial Positions: Links and nodes were not being positioned initially
2. Incorrect Link References: Links were referencing numeric indices instead of actual node objects  
3. Missing Simulation Tick Handler: No dynamic position updates during force simulation

### Solution:
- Added Initial Positioning: Set initial x,y coordinates for links and nodes
- Fixed Link References: Links now reference actual node objects instead of indices
- Added Tick Handler: Dynamic position updates during simulation

### Expected Results:
- Graph Nodes Visible: Nodes should appear as circles with labels (A, B, C, etc.)
- Links Connected: Edges should connect nodes properly
- Interactive: Drag-and-drop functionality should work
- Force Simulation: Nodes should settle into natural positions
- BFS/DFS Traversal: Algorithm visualization should highlight nodes and edges

### Files Changed:
- algorithms/bfs-dfs-graph-traversal.html - Fixed D3.js rendering and simulation

This fix ensures the BFS/DFS Graph Traversal visualization works properly with interactive nodes, connected edges, and smooth algorithm animations.