### PR TITLE
feat: restore Vercel deployment workflow and add setup guide

### DIFF
--- a/.github/VERCEL_SETUP.md
+++ b/.github/VERCEL_SETUP.md
@@ -1,0 +1,44 @@
+# Vercel Deployment Setup Guide
+
+## 🔧 **Required GitHub Secrets**
+
+To enable Vercel deployment, you need to add these secrets to your GitHub repository:
+
+### 1. **VERCEL_TOKEN**
+- Go to [Vercel Dashboard](https://vercel.com/account/tokens)
+- Create a new token with appropriate permissions
+- Copy the token value
+
+### 2. **VERCEL_ORG_ID**
+- Go to [Vercel Dashboard](https://vercel.com/account)
+- Copy your Organization ID from the URL or settings
+
+### 3. **VERCEL_PROJECT_ID**
+- Go to your project in Vercel Dashboard
+- Copy the Project ID from the project settings
+
+## 📋 **How to Add Secrets to GitHub**
+
+1. Go to your GitHub repository
+2. Click **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Add each secret:
+   - Name: `VERCEL_TOKEN`, Value: `[your-vercel-token]`
+   - Name: `VERCEL_ORG_ID`, Value: `[your-org-id]`
+   - Name: `VERCEL_PROJECT_ID`, Value: `[your-project-id]`
+
+## 🚀 **Expected Results**
+
+Once secrets are configured:
+- ✅ Vercel deployments will work automatically
+- ✅ GitHub will show deployment stats and counts
+- ✅ Site will be deployed to: `https://prepguides-dev.vercel.app`
+- ✅ Preview deployments will work for PRs
+
+## 🔍 **Troubleshooting**
+
+If deployments still fail:
+1. Verify all three secrets are correctly set
+2. Check Vercel token permissions
+3. Ensure project exists in Vercel dashboard
+4. Check GitHub Actions logs for specific error messages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy to Vercel
 
 on:
   push:
@@ -6,47 +6,29 @@ on:
   pull_request:
     branches: [ main ]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
         with:
-          path: '.'
-      
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./
+          scope: ${{ secrets.VERCEL_ORG_ID }}
       
       - name: Deployment Status
         run: |
           echo "🚀 Deployment completed successfully!"
           echo "📊 This will show deployment stats in GitHub"
-          echo "🔗 Site deployed to: ${{ steps.deployment.outputs.page_url }}"
+          echo "🔗 Site deployed to: https://prepguides-dev.vercel.app"
 
   preview:
     runs-on: ubuntu-latest
@@ -56,16 +38,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Preview Validation
-        run: |
-          echo "🔍 Validating files for preview deployment..."
-          find . -name "*.html" -not -path "./.git/*" | head -5 | while read file; do
-            echo "Preview checking: $file"
-          done
-          echo "✅ Preview validation completed"
+      - name: Deploy Preview to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./
+          scope: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-args: '--prod=false'
       
-      - name: Preview Ready
+      - name: Preview Deployment Status
         run: |
-          echo "🔍 Preview deployment ready!"
+          echo "🔍 Preview deployment completed!"
           echo "📊 This will show preview deployment stats in GitHub"
-          echo "✅ Preview validation completed successfully"


### PR DESCRIPTION
## 🔄 **Restore Vercel Deployment**

### ✅ **Changes Made:**
- **Restored original Vercel deployment workflow** in 
- **Removed GitHub Pages workflow** (replaced with Vercel)
- **Deleted ** (no longer needed)
- **Added ** with detailed setup instructions

### 🔧 **Required Setup:**
To make Vercel deployment work, you need to add these GitHub secrets:
-  - From Vercel dashboard
-  - Your Vercel organization ID  
-  - Your Vercel project ID

### 📋 **Setup Instructions:**
1. Go to GitHub repo → Settings → Secrets and variables → Actions
2. Add the three required secrets (see  for details)
3. Once secrets are added, deployments will work automatically

### 🎯 **Expected Results:**
- ✅ Vercel deployments will work (once secrets are configured)
- ✅ GitHub will show deployment stats and counts
- ✅ Site deployed to: 
- ✅ Preview deployments for PRs

**Note:** The workflow will fail until the Vercel secrets are properly configured in GitHub repository settings.