### PR TITLE
fix: add instructions to disable failing GitHub Pages environment

### DIFF
--- a/.github/DISABLE_GITHUB_PAGES.md
+++ b/.github/DISABLE_GITHUB_PAGES.md
@@ -1,0 +1,33 @@
+# Disable GitHub Pages
+
+## 🚨 **Issue:**
+The repository has a failing `github-pages` environment that was created when we had GitHub Pages deployment workflows. Since we now use Vercel for deployments, this environment is no longer needed and is causing failures.
+
+## ✅ **Solution:**
+Follow these steps to disable GitHub Pages:
+
+### **Step 1: Disable GitHub Pages in Repository Settings**
+1. Go to your GitHub repository: https://github.com/prepguides/prepguides.dev
+2. Click on **Settings** tab
+3. In the left sidebar, click on **Pages**
+4. Under **Source**, change it from the current setting to **"None"**
+5. Click **Save**
+
+### **Step 2: Verify Environment Cleanup**
+After disabling GitHub Pages:
+1. Go to **Actions** → **Environments**
+2. The `github-pages` environment should no longer appear
+3. Only `Production` and `Preview` (Vercel) environments should remain
+
+## 🎯 **Expected Results:**
+- ✅ No more failing `github-pages` environment
+- ✅ Only Vercel environments remain active
+- ✅ Clean deployment status without conflicts
+- ✅ All deployments handled by Vercel bot
+
+## 📋 **Current Environments:**
+- ✅ **Production** - Vercel production deployments
+- ✅ **Preview** - Vercel preview deployments  
+- ❌ **github-pages** - Should be removed (failing)
+
+This will resolve the failing GitHub Pages environment issue! 🚀


### PR DESCRIPTION
## 🚨 **Fix Failing GitHub Pages Environment**

### ❌ **Issue:**
The repository has a failing  environment that was created when we had GitHub Pages deployment workflows. Since we now use Vercel for deployments, this environment is no longer needed and is causing failures.

### ✅ **Solution:**
Added step-by-step instructions to disable GitHub Pages in repository settings.

### 📋 **What's Added:**
- **** - Complete instructions to:
  1. Disable GitHub Pages in repository settings
  2. Verify environment cleanup
  3. Confirm only Vercel environments remain

### 🎯 **Expected Results:**
- ✅ No more failing  environment
- ✅ Only Vercel environments remain active ( and )
- ✅ Clean deployment status without conflicts
- ✅ All deployments handled by Vercel bot

### 📋 **Current Environments:**
- ✅ **Production** - Vercel production deployments
- ✅ **Preview** - Vercel preview deployments  
- ❌ **github-pages** - Should be removed (failing)

This will resolve the failing GitHub Pages environment issue! 🚀