### PR TITLE
fix: Enable GitHub login button by updating Client ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
     <script>
         // GitHub OAuth Configuration
         window.GITHUB_CONFIG = {
-            clientId: 'your_github_client_id_here', // Replace with actual client ID
+            clientId: 'Ov23liX9YTDE0e7OaBLs', // Actual GitHub Client ID
             isConfigured: true // Set to true since environment variables are configured
         };
     </script>


### PR DESCRIPTION
## 🐛 Issue
The GitHub login button appears disabled/subdued because the Client ID was still set to a placeholder value.

## ✅ Fix
- Updated  from placeholder to actual GitHub OAuth Client ID
- This enables the login button to work properly
- Fixes the OAuth authentication flow

## 🧪 Testing
- [ ] Login button should now be active and clickable
- [ ] GitHub OAuth flow should work properly
- [ ] User authentication should complete successfully

## 📝 Notes
- Uses the actual Client ID: 
- This is a quick fix for the immediate login issue
- Should be merged before the form redesign PR