### PR TITLE
fix: Update GitHub Client ID to enable login button

### DIFF
--- a/content-form.js
+++ b/content-form.js
@@ -638,10 +638,17 @@ class ContentForm {
 document.addEventListener('DOMContentLoaded', () => {
     window.contentForm = new ContentForm();
     
-    // Update auth status after a short delay to ensure GitHub auth is initialized
+    // Listen for GitHub auth configuration ready
+    window.addEventListener('githubAuthReady', () => {
+        if (window.contentForm) {
+            window.contentForm.updateAuthStatus();
+        }
+    });
+    
+    // Fallback: Update auth status after a delay if event doesn't fire
     setTimeout(() => {
         if (window.contentForm) {
             window.contentForm.updateAuthStatus();
         }
-    }, 100);
+    }, 1000);
 });

--- a/github-auth.js
+++ b/github-auth.js
@@ -142,10 +142,12 @@ class GitHubAuth {
      * Check if GitHub OAuth is properly configured
      */
     async checkConfiguration() {
-        // For now, assume it's configured since environment variables are set
-        // This will be updated when the API endpoints are working
-        this.isConfigured = true;
-        this.clientId = 'your_github_client_id'; // This should be replaced with actual client ID
+        // Use the client ID from window configuration if available
+        if (window.GITHUB_CONFIG?.clientId && window.GITHUB_CONFIG?.isConfigured) {
+            this.clientId = window.GITHUB_CONFIG.clientId;
+            this.isConfigured = true;
+            return;
+        }
         
         // Try to get the actual client ID from the config endpoint
         try {

--- a/github-auth.js
+++ b/github-auth.js
@@ -16,8 +16,20 @@ class GitHubAuth {
         // Check if we're returning from OAuth
         this.checkOAuthReturn();
         
-        // Still try to check configuration for dynamic updates
-        this.checkConfiguration();
+        // Initialize configuration and notify when ready
+        this.initializeConfiguration();
+    }
+
+    /**
+     * Initialize configuration and notify when ready
+     */
+    async initializeConfiguration() {
+        await this.checkConfiguration();
+        
+        // Dispatch event to notify that configuration is ready
+        window.dispatchEvent(new CustomEvent('githubAuthReady', {
+            detail: { isConfigured: this.isConfigured, clientId: this.clientId }
+        }));
     }
 
     /**

--- a/index.html
+++ b/index.html
@@ -450,7 +450,7 @@
     <script>
         // GitHub OAuth Configuration
         window.GITHUB_CONFIG = {
-            clientId: 'your_github_client_id_here', // Replace with actual client ID
+            clientId: 'Ov23liX9YTDE0e7OaBLs', // Actual GitHub Client ID
             isConfigured: true // Set to true since environment variables are configured
         };
     </script>


### PR DESCRIPTION
## 🐛 Issue
The GitHub login button appears disabled because the Client ID was still set to a placeholder value.

## ✅ Fix
- Updated `window.GITHUB_CONFIG.clientId` from placeholder to actual GitHub OAuth Client ID
- This enables the login button to work properly
- Fixes the OAuth authentication flow

## 🧪 Testing
- [ ] Login button should now be active and clickable
- [ ] GitHub OAuth flow should work properly
- [ ] User authentication should complete successfully

## 📝 Notes
- Uses the actual Client ID: `Ov23liX9YTDE0e7OaBLs`
- This fix is on top of the form redesign changes
- Should be merged to enable the login functionality