### PR TITLE
Fix confirm submit button loading state

### DIFF
--- a/content-form.js
+++ b/content-form.js
@@ -122,7 +122,10 @@ class ContentForm {
                     <div id="preview-content" class="preview-content"></div>
                     <div class="preview-actions">
                         <button id="back-to-form-btn" class="back-btn">Back to Form</button>
-                        <button id="confirm-submit-btn" class="confirm-submit-btn">Confirm & Submit</button>
+                        <button id="confirm-submit-btn" class="confirm-submit-btn">
+                            <span class="btn-text">Confirm & Submit</span>
+                            <span class="btn-loading" style="display: none;">Creating PR...</span>
+                        </button>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Problem
The confirm submit button was throwing a TypeError when clicked:
```
TypeError: Cannot read properties of null (reading 'style')
at ContentForm.confirmSubmit (content-form.js:707:17)
```

## Root Cause
The `confirmSubmit` method was trying to access `.btn-text` and `.btn-loading` elements inside the confirm submit button, but these elements didn't exist in the HTML.

## Solution
Added the missing HTML structure to the confirm submit button:
```html
<button id="confirm-submit-btn" class="confirm-submit-btn">
    <span class="btn-text">Confirm & Submit</span>
    <span class="btn-loading" style="display: none;">Creating PR...</span>
</button>
```

## Benefits
- ✅ **Loading state**: Button shows "Creating PR..." when submitting
- ✅ **No more errors**: Fixes the TypeError completely
- ✅ **Better UX**: Users see visual feedback during PR creation

## Files Changed
- `content-form.js`: Added missing button loading elements

Fixes the confirm submit button functionality for the GitHub-integrated content submission system.