### PR TITLE
Add cache-busting to fix JavaScript caching issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,6 +472,6 @@
         console.log('GitHub Config set:', window.GITHUB_CONFIG);
     </script>
         <script src="github-auth.js"></script>
-        <script src="content-form.js"></script>
+        <script src="content-form.js?v=4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
The production site is still showing the old `formatPreviewContent` error even after the fix was merged. This is because browsers are caching the old JavaScript file.

## Root Cause
The browser is using a cached version of `content-form.js` that doesn't include the `formatPreviewContent` fix, causing the same TypeError to persist.

## Solution
Added cache-busting parameter to force browser to reload the JavaScript:
```html
<script src="content-form.js?v=4"></script>
```

## Benefits
- ✅ **Forces fresh JavaScript load**: Browser will download the latest version
- ✅ **Fixes cached error**: Ensures production uses the fixed `formatPreviewContent` method
- ✅ **Immediate effect**: No need to wait for cache expiration

## Files Changed
- `index.html`: Added cache-busting parameter to content-form.js

This should resolve the persistent `formatPreviewContent` error in production.