### PR TITLE
Fix null reference error in PR description generation

### DIFF
--- a/content-form.js
+++ b/content-form.js
@@ -482,6 +482,7 @@ class ContentForm {
             category: formData.get('category'),
             subtopic: formData.get('subtopic'),
             description: formData.get('description'),
+            content: formData.get('description'), // Use description as content for consistency
             type: contentType,
             path: formData.get('path'),
             addedDate: new Date().toISOString().split('T')[0],

--- a/github-auth.js
+++ b/github-auth.js
@@ -496,7 +496,7 @@ class GitHubAuth {
         <p><strong>Description:</strong> ${contentData.description}</p>
         
         <div class="main-content">
-            ${contentData.content}
+            ${contentData.content || contentData.description || ''}
         </div>
         
         <hr>
@@ -520,7 +520,7 @@ class GitHubAuth {
 ${contentData.description}
 
 ### Content Preview
-${contentData.content.substring(0, 200)}${contentData.content.length > 200 ? '...' : ''}
+${(contentData.content || contentData.description || '').substring(0, 200)}${(contentData.content || contentData.description || '').length > 200 ? '...' : ''}
 
 ### Review Checklist
 - [ ] Content is technically accurate


### PR DESCRIPTION
## Problem
The `Confirm & Submit` button was failing with a TypeError:
```
TypeError: Cannot read properties of null (reading 'substring')
at GitHubAuth.generatePRDescription (github-auth.js:523:23)
```

## Root Cause
The `generatePRDescription` method was trying to access `contentData.content.substring()`, but `contentData.content` was `null`. The form submission creates a `description` field but the PR generation expects a `content` field.

## Solution
1. **Added null safety checks** in `generatePRDescription`:
   ```javascript
   ${(contentData.content || contentData.description || '').substring(0, 200)}
   ```

2. **Added content field** to form submission for consistency:
   ```javascript
   content: formData.get('description'), // Use description as content for consistency
   ```

## Benefits
- ✅ **Fixes PR creation**: No more null reference errors
- ✅ **Backward compatible**: Works with both content and description fields
- ✅ **Consistent data structure**: Form submission now includes both fields
- ✅ **Robust error handling**: Graceful fallback when content is missing

## Files Changed
- `github-auth.js`: Added null safety checks in `generatePRDescription`
- `content-form.js`: Added content field to form submission

This should resolve the `Confirm & Submit` button functionality completely.