### PR TITLE
Fix content submission data issues

### DIFF
--- a/content-form.js
+++ b/content-form.js
@@ -485,6 +485,7 @@ class ContentForm {
             content: formData.get('description'), // Use description as content for consistency
             type: contentType,
             path: formData.get('path'),
+            repo: formData.get('repo'), // Add repo field
             addedDate: new Date().toISOString().split('T')[0],
             status: 'pending'
         };
@@ -535,6 +536,12 @@ class ContentForm {
      * Generate content ID
      */
     generateContentId(title, category) {
+        // Validate inputs
+        if (!title || !category) {
+            console.error('generateContentId: Missing title or category', { title, category });
+            return 'unknown-content';
+        }
+        
         const id = title.toLowerCase()
             .replace(/[^a-z0-9\s]/g, '')
             .replace(/\s+/g, '-')

--- a/github-auth.js
+++ b/github-auth.js
@@ -452,12 +452,22 @@ class GitHubAuth {
      * Create content file in the repository
      */
     async createContentFile(branchName, contentData) {
+        // Debug: Log content data to identify issues
+        console.log('Creating content file with data:', contentData);
+        
+        // Validate required fields
+        if (!contentData.id) {
+            throw new Error('Content ID is missing or undefined');
+        }
+        
         // Create content payload JSON file in .github/content-payloads/ folder
         const contentJson = this.formatContentAsJson(contentData);
         const encodedContent = btoa(unescape(encodeURIComponent(contentJson)));
 
         // Use the correct path for content payloads
         const submissionPath = `.github/content-payloads/${contentData.id}-payload.json`;
+        
+        console.log('Creating payload file at:', submissionPath);
 
         const response = await fetch(`https://api.github.com/repos/prepguides/prepguides.dev/contents/${submissionPath}`, {
             method: 'PUT',
@@ -521,7 +531,9 @@ class GitHubAuth {
                 title: contentData.title,
                 description: contentData.description,
                 type: contentData.type || 'guide',
-                status: contentData.status || 'pending'
+                status: contentData.status || 'pending',
+                repo: contentData.repo || '',
+                path: contentData.path || ''
             },
             validation: {
                 repoAccessible: true,
@@ -532,13 +544,6 @@ class GitHubAuth {
         };
 
         // Add type-specific fields to content
-        if (contentData.type === 'guide' && contentData.repo) {
-            payloadJson.content.repo = contentData.repo;
-        }
-
-        if (contentData.path) {
-            payloadJson.content.path = contentData.path;
-        }
 
         if (contentData.features && contentData.features.length > 0) {
             payloadJson.content.features = contentData.features;


### PR DESCRIPTION
## Problem
Multiple critical issues with content submission system:

1. **Undefined ID**: Content ID is undefined, causing `undefined-payload.json` files
2. **Missing repo/path fields**: The payload JSON doesn't include `repo` and `path` fields in the content section
3. **Data validation**: No validation for required fields leading to malformed submissions

## Root Cause
- Form data collection was missing the `repo` field in the `contentData` object
- No validation for undefined/null values in `generateContentId`
- Conditional logic for `repo` and `path` fields meant they weren't always included

## Solution
### Key Fixes:
1. **Added repo field collection**:
   ```javascript
   repo: formData.get('repo'), // Add repo field
   ```

2. **Added ID validation**:
   ```javascript
   if (!title || !category) {
       console.error('generateContentId: Missing title or category', { title, category });
       return 'unknown-content';
   }
   ```

3. **Always include repo and path in payload**:
   ```json
   "content": {
     "id": "content-id",
     "title": "Content Title",
     "description": "Description",
     "type": "guide",
     "status": "pending",
     "repo": "owner/repo-name",
     "path": "path/to/file.md"
   }
   ```

4. **Added debugging and validation**:
   - Log content data during creation
   - Validate required fields before processing
   - Better error messages for troubleshooting

## Benefits
- ✅ **No more undefined files**: Proper ID generation and validation
- ✅ **Complete data structure**: Always includes repo and path fields
- ✅ **Better debugging**: Console logs help identify issues
- ✅ **Robust validation**: Prevents malformed submissions
- ✅ **Matches template**: Consistent with working payload format

## Files Changed
- `content-form.js`: Added repo field collection and ID validation
- `github-auth.js`: Always include repo/path fields and added debugging

This should resolve the `undefined-payload.json` issue and ensure proper data structure matching the working template.