### PR TITLE
Fix content status issue - always set to 'active' when processing through automation

### DIFF
--- a/scripts/merge-content.js
+++ b/scripts/merge-content.js
@@ -176,7 +176,7 @@ function mergePayload(baseConfig, payload) {
     baseConfig.categories[category].subtopics[subtopic].content[existingContentIndex] = {
       ...content,
       addedDate: metadata.submissionDate || new Date().toISOString().split('T')[0],
-      status: content.status || 'active'
+      status: 'active' // Always set to active when processing through automation
     };
     console.log(`🔄 Updated existing content: ${content.title}`);
   } else {
@@ -184,7 +184,7 @@ function mergePayload(baseConfig, payload) {
     baseConfig.categories[category].subtopics[subtopic].content.push({
       ...content,
       addedDate: metadata.submissionDate || new Date().toISOString().split('T')[0],
-      status: content.status || 'active'
+      status: 'active' // Always set to active when processing through automation
     });
     console.log(`➕ Added new content: ${content.title}`);
   }


### PR DESCRIPTION
## Problem
Submitted content was not appearing on the website even though it was being processed by the automation. The issue was that content cards were not visible on category pages (like System Design page showing empty content area).

## Root Cause
The automation was preserving the  status from payload files instead of setting it to  when processing content through the automation workflow.

### The Issue:
1. **Payload had ** - Submitted content had status set to pending
2. **Merge logic preserved the status** - Script used , which kept  instead of defaulting to 
3. **HTML generation only shows active content** - The  function only displays content with 
4. **Result: Empty content area** - Since content was , it wasn't displayed on category pages

## Solution
Changed the merge logic to **always set content status to ** when processing through automation:

```javascript
// Before (problematic):
status: content.status || 'active'  // Kept 'pending' status

// After (fixed):
status: 'active'  // Always set to active when processing through automation
```

## Why This Makes Sense
- **Content submitted through the form** should be visible once processed by automation
- **The automation acts as the approval process** - if it runs successfully, the content should be active
- **Pending status** should only be used before automation processing, not after

## Expected Result
Now when the automation processes content submissions (like Go Patterns), the content will:
1. ✅ Be properly merged into  with 
2. ✅ Appear as content cards on the respective category pages
3. ✅ Be visible in the HTML with proper links to the template renderer

## Files Changed
- `scripts/merge-content.js`: Fixed content status logic to always set to 'active'

This should resolve the issue where submitted content was not visible on the website.