### PR TITLE
Fix OAuth authentication: Add missing redirect_uri parameter

### DIFF
--- a/github-auth.js
+++ b/github-auth.js
@@ -64,6 +64,8 @@ class GitHubAuth {
     async processOAuthCode(code, state) {
         try {
             console.log('Processing OAuth code:', code);
+            console.log('OAuth state:', state);
+            console.log('Current URL:', window.location.href);
             
             // Process the OAuth callback
             const response = await fetch('/api/auth/github', {
@@ -78,10 +80,17 @@ class GitHubAuth {
             });
 
             console.log('OAuth response status:', response.status);
+            console.log('OAuth response headers:', Object.fromEntries(response.headers.entries()));
 
             if (!response.ok) {
                 const errorData = await response.json();
                 console.error('OAuth error response:', errorData);
+                
+                // Handle specific OAuth errors
+                if (errorData.message && errorData.message.includes('incorrect or expired')) {
+                    throw new Error('OAuth code has expired. Please try logging in again.');
+                }
+                
                 throw new Error(errorData.message || 'Authentication failed');
             }
 
@@ -206,10 +215,12 @@ class GitHubAuth {
         }
 
         // For now, let's use a simple approach - redirect to GitHub and handle the callback manually
+        const redirectUri = this.getCallbackUri();
         const authUrl = `https://github.com/login/oauth/authorize?` +
             `client_id=${this.clientId}&` +
             `scope=${this.scope}&` +
-            `state=${this.generateState()}`;
+            `state=${this.generateState()}&` +
+            `redirect_uri=${encodeURIComponent(redirectUri)}`;
         
         // Store that we're in the middle of OAuth
         localStorage.setItem('oauth_in_progress', 'true');


### PR DESCRIPTION
## 🔧 Fix OAuth Authentication Issue

### Problem
Users were experiencing "Authentication Failed" errors with the message "The code passed is incorrect or expired" when trying to authenticate with GitHub OAuth.

### Root Cause
The OAuth authorization request was missing the `redirect_uri` parameter, which GitHub requires to match exactly what's configured in the OAuth app settings.

### Solution
- ✅ **Added `redirect_uri` parameter** to the GitHub OAuth authorization URL
- ✅ **Improved error handling** for expired OAuth codes with specific user-friendly messaging
- ✅ **Enhanced logging** for better OAuth debugging and troubleshooting

### Changes Made
1. **Modified `github-auth.js`**:
   - Added `redirect_uri` parameter to OAuth authorization URL
   - Improved error handling for "incorrect or expired" codes
   - Added comprehensive logging for debugging

### Technical Details
```javascript
// Before
const authUrl = `https://github.com/login/oauth/authorize?` +
    `client_id=${this.clientId}&` +
    `scope=${this.scope}&` +
    `state=${this.generateState()}`;

// After  
const redirectUri = this.getCallbackUri();
const authUrl = `https://github.com/login/oauth/authorize?` +
    `client_id=${this.clientId}&` +
    `scope=${this.scope}&` +
    `state=${this.generateState()}&` +
    `redirect_uri=${encodeURIComponent(redirectUri)}`;
```

### Testing
- [x] OAuth flow now includes proper redirect_uri parameter
- [x] Error handling provides clear feedback for expired codes
- [x] Enhanced logging helps with debugging OAuth issues

### Impact
- 🎯 **Resolves** "The code passed is incorrect or expired" error
- 🚀 **Improves** user experience with better error messages
- 🔍 **Enhances** debugging capabilities for OAuth issues

Closes: OAuth authentication failures