### PR TITLE
Fix targetInstallation scope error in bot API

### DIFF
--- a/api/github/create-content-pr.js
+++ b/api/github/create-content-pr.js
@@ -181,12 +181,13 @@ async function tryGitHubAppApproach(contentData, userToken) {
 
         // Find installation
         console.log('🔍 Finding installations...');
+        let targetInstallation;
         try {
             const installations = await tempOctokit.apps.listInstallations();
             console.log('Found installations:', installations.data.length);
             console.log('Available installations:', installations.data.map(i => i.account.login));
             
-            const targetInstallation = installations.data.find(installation => 
+            targetInstallation = installations.data.find(installation => 
                 installation.account.login === 'prepguides'
             );
 


### PR DESCRIPTION
## 🐛 Problem
The content submission was failing with error: `targetInstallation is not defined`

## 🔍 Root Cause
The `targetInstallation` variable was declared inside a try-catch block but was being used outside of it, causing a scope error.

## ✅ Solution
- Declare `targetInstallation` variable outside the try-catch block
- Assign it inside the try-catch block
- Make it accessible throughout the function scope

## 🧪 Testing
- [x] Fixed variable scope issue
- [ ] Test content submission locally
- [ ] Verify end-to-end functionality

## 🎯 Expected Result
Content submission should work without the `targetInstallation is not defined` error.

Fixes the issue where users get:
```
Content submission is temporarily unavailable. GitHub App error.
details: { githubAppError: "targetInstallation is not defined" }
```