### PR TITLE
Fix payload generation to use actual form data

### DIFF
--- a/api/github/create-content-pr.js
+++ b/api/github/create-content-pr.js
@@ -39,6 +39,9 @@ export default async function handler(req, res) {
         console.log('Content ID:', contentData.id);
         console.log('Content Title:', contentData.title);
         console.log('Content Category:', contentData.category);
+        console.log('Content Repo:', contentData.repo);
+        console.log('Content Path:', contentData.path);
+        console.log('Content Type:', contentData.type);
         console.log('User Token present:', !!userToken);
 
         // Try GitHub App approach - this should work without requiring user fork
@@ -540,9 +543,9 @@ function generatePayloadContent(contentData, user) {
             id: contentData.id,
             title: contentData.title,
             description: contentData.description,
-            repo: "prepguides/prepguides.dev", // Default to main repo
-            path: `content/${contentData.category}/${contentData.id}.md`, // Default path structure
-            type: "guide", // Default to guide type
+            repo: contentData.repo || "prepguides/prepguides.dev", // Use form data or default
+            path: contentData.path || `content/${contentData.category}/${contentData.id}.md`, // Use form data or default
+            type: contentData.type || "guide", // Use form data or default
             status: "active"
         },
         validation: {


### PR DESCRIPTION
## 🐛 Problem

The GitHub Actions validation was failing because the bot API was generating payload files with hardcoded default values instead of using the actual form data:

- **Expected**: `repo: "prepguides/go-interviews"`, `path: "patterns/README.md"`
- **Actual**: `repo: "prepguides/prepguides.dev"`, `path: "content/system-design/system-design-concurrency-model.md"`

This caused the validation to fail with a 404 error because it was looking for a file that doesn't exist in the wrong repository.

## ✅ Solution

Updated the `generatePayloadContent` function in `api/github/create-content-pr.js` to use the actual form data:

```javascript
content: {
    id: contentData.id,
    title: contentData.title,
    description: contentData.description,
    repo: contentData.repo || "prepguides/prepguides.dev", // Use form data or default
    path: contentData.path || `content/${contentData.category}/${contentData.id}.md`, // Use form data or default
    type: contentData.type || "guide", // Use form data or default
    status: "active"
},
```

## 🧪 Testing

- ✅ Verified payload now correctly uses `repo: "prepguides/go-interviews"`
- ✅ Verified payload now correctly uses `path: "patterns/README.md"`
- ✅ Verified payload now correctly uses `type: "Guide (GitHub Markdown)"`

## 📝 Expected Result

The GitHub Actions validation should now pass because it will be looking for the correct file in the correct repository:
- ✅ Repository accessible: `prepguides/go-interviews`
- ✅ File accessible: `prepguides/go-interviews/patterns/README.md`

## 🔍 Additional Changes

- Added logging to show repo, path, and type values being received for better debugging
- Maintains backward compatibility with fallback defaults if form data is missing